### PR TITLE
Added patch for the reimplant gene ability

### DIFF
--- a/Source/Patch_Xenogerm.cs
+++ b/Source/Patch_Xenogerm.cs
@@ -14,4 +14,17 @@ namespace ForceXenogermImlpantation
             }
         }
     }
+
+    // Method body is basically the same as PawnIdeoDisallowsImplanting, but this one requires two parameters for checks against both the implanter and implantee
+    [HarmonyPatch(typeof(CompAbilityEffect_ReimplantXenogerm), nameof(CompAbilityEffect_ReimplantXenogerm.PawnIdeoCanAcceptReimplant))]
+    static class Patch_ForceReimplantXenogerm
+    {
+        static void Postfix(CompAbilityEffect_ReimplantXenogerm __instance, ref bool __result, Pawn implantee)
+        {
+            // This method checks for a true value unlike PawnIdeoDisallowsImplanting which checks for false
+            if( (implantee.IsSlaveOfColony || implantee.IsPrisonerOfColony) && !__result ){
+                __result = true;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Patches CompAbilityEffect_ReimplantXenogerm.PawnIdeoCanAcceptReimplant so that you can force implant xenogerms via the gene implanter ability also.